### PR TITLE
Add hw_breakpoint.c include for BOFS

### DIFF
--- a/source/spoof_callstack.c
+++ b/source/spoof_callstack.c
@@ -1,5 +1,8 @@
 #include "spoof_callstack.h"
 #include "hw_breakpoint.h"
+#ifdef BOF
+#include "hw_breakpoint.c"
+#endif
 
 PVOID from_fake_to_real(PSTACK_INFO stack_info, PVOID pointer)
 {


### PR DESCRIPTION
Add hw_breakpoint.c for BOF to ensure the set_hwbp and unset_hwbp functions are compiled.

CS error: 
Unknown symbol 'set_hwbp'
Unknown symbol 'unset_hwbp'
